### PR TITLE
Alter behavior of debug flag

### DIFF
--- a/src/graphiteudp.py
+++ b/src/graphiteudp.py
@@ -27,9 +27,8 @@ class GraphiteUDPClient:
       if self._prefix is not None:
          message = self._prefix + "." + message
 
-      if self._debug:
-         logger.debug("%s -> %s" % (repr(message), repr(self._addr)))
-      else:
+      logger.debug("%s -> %s" % (repr(message), repr(self._addr)))
+      if not self._debug:
          try:
             (sock, addr) = self._host.get()
             sock.sendto(message, addr)


### PR DESCRIPTION
Always log the intended message (use Python logging mechanism to control whether the log message is emitted)
Use the debug flag strictly to control whether or not the UDP message is sent.

---

I found it a big confusing that the debug flag affected the ultimate functionality, I guess it's being used as a "test" flag in actuality.  I think it's helpful to be able to debug log the message even when it's actually being sent, and if I want to squelch it, I can tell Python logging to do that.