### PR TITLE
remove python-support dependency due to deprecation in ubuntu

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+python-graphiteudp (0.0.5) unstable; urgency=low
+
+  * Removing deprecated python-support deps for ubuntu 16.04
+
+ -- Derp Ston <derpston+packaging@sleepygeek.org>  Tue, 13 Mar 2018 15:11:00 +0000
+ 
 python-graphiteudp (0.0.2) unstable; urgency=low
 
   * Using python-socketcache to manage socket creation, DNS, etc, to avoid

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,6 @@ Priority: optional
 Maintainer: Derp Ston <derpston+packaging@sleepygeek.org>
 Build-Depends:
     debhelper (>= 6.0.0),
-    python-support (>= 0.90)
 Standards-Version: 3.9.1
 
 Package: python-graphiteudp
@@ -12,7 +11,6 @@ Architecture: all
 Depends:
     ${python:Depends},
     ${misc:Depends},
-    python-socketcache
 Description: Python module for sending UDP packets to Graphite
  Supports using a cache of socket objects to ensure minimal
  impact on application performance, supports a debug mode where

--- a/debian/control
+++ b/debian/control
@@ -4,6 +4,7 @@ Priority: optional
 Maintainer: Derp Ston <derpston+packaging@sleepygeek.org>
 Build-Depends:
     debhelper (>= 6.0.0),
+    python-socketcache,
 Standards-Version: 3.9.1
 
 Package: python-graphiteudp

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from distutils.core import setup
 
 setup(
       name = 'graphiteudp'
-   ,  version = '0.0.4'
+   ,  version = '0.0.5'
    ,  description = 'A clean interface for sending metrics to Graphite over UDP'
    ,  long_description = """Uses a cache of socket objects to minimise DNS lookups and \
 performance impact on the application. Supports a debug mode that logs metric messages, \
@@ -16,4 +16,3 @@ and handles network errors by logging an exception."""
    ,  package_dir = {'': 'src'}
    ,  install_requires = ['socketcache', 'contextlib2']
    )
-

--- a/src/graphiteudp.py
+++ b/src/graphiteudp.py
@@ -1,4 +1,4 @@
-__version__ = "0.0.2"
+__version__ = "0.0.5"
 
 import time
 import logging


### PR DESCRIPTION
python-support is removed in xenial (16.04) onwards, replaced by dh-python so removing the dependency here to allow packages to be built on newer distros.